### PR TITLE
Fix for KeyError: "Blob or Tree named 'data' not found"

### DIFF
--- a/reconstruct_historical_data.py
+++ b/reconstruct_historical_data.py
@@ -52,10 +52,13 @@ if __name__ == "__main__":
         file_ext = json_file.suffix
         output_path = Path(output_dir) / json_file.parents[0].name
         
-        revlist = (
-            (commit, (commit.tree / str(json_file)).data_stream.read())
-            for commit in repo.iter_commits(paths=str(json_file))
-        )
+        try:
+            revlist = (
+                (commit, (commit.tree / str(json_file)).data_stream.read())
+                for commit in repo.iter_commits(paths=str(json_file))
+            )
+        except KeyError:
+            continue
 
         if jsonl:
             write_jsonl_changes(output_path, file_stem, revlist)


### PR DESCRIPTION
When `json_file` is not found in `commit.tree` the concatination fails with an exception. This will happen if the commit does not contain the data we are looking for.

This solution simply soft-fails and skips the processing and continues with the next `json_file` item.